### PR TITLE
Add notify dependents to trigger image releases

### DIFF
--- a/.github/workflows/notify_dependents.yml
+++ b/.github/workflows/notify_dependents.yml
@@ -18,3 +18,10 @@ jobs:
           -H "Content-Type: application/json" \
           -d '{"event_type": "lib-version-updated"}' \
           https://api.github.com/repos/doda25-team10/model-service/dispatches
+      - name: Trigger app-service release
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{"event_type": "lib-version-updated"}' \
+          https://api.github.com/repos/doda25-team10/app-service/dispatches

--- a/.github/workflows/notify_dependents.yml
+++ b/.github/workflows/notify_dependents.yml
@@ -1,0 +1,18 @@
+name: Notify dependents
+
+on:
+  push:
+    paths:
+      - 'pom.xml'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger model-service release
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{"event_type": "lib-version-updated"}' \
+          https://api.github.com/repos/doda25-team10/model-service/dispatches

--- a/.github/workflows/notify_dependents.yml
+++ b/.github/workflows/notify_dependents.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - 'pom.xml'
+    branches:
+      - main
 
 jobs:
   notify:


### PR DESCRIPTION
Introduces a new workflow that is automatically triggered whenever the pom.xml file is changed in main. In turn, this will trigger dependencies to update their images, such as the model-service. The idea behind this workflow is that whenever we update the version, we should release new images.